### PR TITLE
Parametrize sub tests

### DIFF
--- a/qutebrowser/misc/split.py
+++ b/qutebrowser/misc/split.py
@@ -127,7 +127,7 @@ def split(s, keep=False):
     """Split a string via ShellLexer.
 
     Args:
-        keep: Whether to keep are special chars in the split output.
+        keep: Whether to keep special chars in the split output.
     """
     lexer = ShellLexer(s)
     lexer.keep = keep

--- a/tests/keyinput/test_basekeyparser.py
+++ b/tests/keyinput/test_basekeyparser.py
@@ -63,44 +63,26 @@ class TestSplitCount:
 
     """Test the _split_count method.
 
-    Attributes:
-        kp: The BaseKeyParser we're testing.
+    Class Attributes:
+        TESTS: list of parameters for the tests, as tuples of
+        (input_key, supports_count, expected)
     """
 
-    @pytest.fixture(autouse=True)
-    def setup(self):
-        self.kp = basekeyparser.BaseKeyParser(0, supports_count=True)
+    TESTS = [
+        ('10', True, (10, '')),
+        ('10foo', True, (10, 'foo')),
+        ('-1foo', True, (None, '-1foo')),
+        ('10e4foo', True, (10, 'e4foo')),
+        ('foo', True, (None, 'foo')),
+        ('10foo', False, (None, '10foo')),
+    ]
 
-    def test_onlycount(self):
+    @pytest.mark.parametrize('input_key, supports_count, expected', TESTS)
+    def test_splitcount(self, input_key, supports_count, expected):
         """Test split_count with only a count."""
-        self.kp._keystring = '10'
-        assert self.kp._split_count() == (10, '')
-
-    def test_normalcount(self):
-        """Test split_count with count and text."""
-        self.kp._keystring = '10foo'
-        assert self.kp._split_count() == (10, 'foo')
-
-    def test_minuscount(self):
-        """Test split_count with a negative count."""
-        self.kp._keystring = '-1foo'
-        assert self.kp._split_count() == (None, '-1foo')
-
-    def test_expcount(self):
-        """Test split_count with an exponential count."""
-        self.kp._keystring = '10e4foo'
-        assert self.kp._split_count() == (10, 'e4foo')
-
-    def test_nocount(self):
-        """Test split_count with only a command."""
-        self.kp._keystring = 'foo'
-        assert self.kp._split_count() == (None, 'foo')
-
-    def test_nosupport(self):
-        """Test split_count with a count when counts aren't supported."""
-        self.kp._supports_count = False
-        self.kp._keystring = '10foo'
-        assert self.kp._split_count() == (None, '10foo')
+        kp = basekeyparser.BaseKeyParser(0, supports_count=supports_count)
+        kp._keystring = input_key
+        assert kp._split_count() == expected
 
 
 @pytest.mark.usefixtures('fake_keyconfig', 'mock_timer')

--- a/tests/keyinput/test_basekeyparser.py
+++ b/tests/keyinput/test_basekeyparser.py
@@ -69,6 +69,7 @@ class TestSplitCount:
     """
 
     TESTS = [
+        # (input_key, supports_count, expected)
         ('10', True, (10, '')),
         ('10foo', True, (10, 'foo')),
         ('-1foo', True, (None, '-1foo')),

--- a/tests/misc/test_split.py
+++ b/tests/misc/test_split.py
@@ -107,24 +107,28 @@ test_data_lines = test_data.strip().splitlines()
 
 
 class TestSplit:
+
     """Test split."""
 
     @pytest.mark.parametrize('cmd, out',
-                             [case.split('/')[:-2] for case in test_data_lines])
+                             [case.split('/')[:-2]
+                              for case in test_data_lines])
     def test_split(self, cmd, out):
         """Test splitting."""
         items = split.split(cmd)
         assert items == out.split('|')
 
     @pytest.mark.parametrize('cmd',
-                             [case.split('/')[0] for case in test_data_lines])
+                             [case.split('/')[0]
+                              for case in test_data_lines])
     def test_split_keep_original(self, cmd):
         """Test if splitting with keep=True yields the original string."""
         items = split.split(cmd, keep=True)
         assert ''.join(items) == cmd
 
     @pytest.mark.parametrize('cmd, _mid, out',
-                             [case.split('/')[:-1] for case in test_data_lines])
+                             [case.split('/')[:-1]
+                              for case in test_data_lines])
     def test_split_keep(self, cmd, _mid, out):
         """Test splitting with keep=True."""
         items = split.split(cmd, keep=True)
@@ -132,6 +136,7 @@ class TestSplit:
 
 
 class TestSimpleSplit:
+
     """Test simple_split."""
 
     TESTS = {
@@ -150,12 +155,16 @@ class TestSimpleSplit:
     def test_str_split_maxsplit_1(self):
         """Test if the behavior matches str.split with maxsplit=1."""
         s = "foo bar baz"
-        assert split.simple_split(s, maxsplit=1) == s.rstrip().split(maxsplit=1)
+        actual = split.simple_split(s, maxsplit=1)
+        expected = s.rstrip().split(maxsplit=1)
+        assert actual == expected
 
     def test_str_split_maxsplit_0(self):
         """Test if the behavior matches str.split with maxsplit=0."""
         s = "  foo bar baz  "
-        assert split.simple_split(s, maxsplit=0) == s.rstrip().split(maxsplit=0)
+        actual = split.simple_split(s, maxsplit=0)
+        expected = s.rstrip().split(maxsplit=0)
+        assert actual == expected
 
     @pytest.mark.parametrize('test, expected', TESTS.items())
     def test_split_keep(self, test, expected):

--- a/tests/misc/test_split.py
+++ b/tests/misc/test_split.py
@@ -170,18 +170,12 @@ class TestSimpleSplit:
         """Test if the behavior matches str.split."""
         assert split.simple_split(test) == test.rstrip().split()
 
-    def test_str_split_maxsplit_1(self):
-        """Test if the behavior matches str.split with maxsplit=1."""
-        s = "foo bar baz"
-        actual = split.simple_split(s, maxsplit=1)
-        expected = s.rstrip().split(maxsplit=1)
-        assert actual == expected
-
-    def test_str_split_maxsplit_0(self):
-        """Test if the behavior matches str.split with maxsplit=0."""
-        s = "  foo bar baz  "
-        actual = split.simple_split(s, maxsplit=0)
-        expected = s.rstrip().split(maxsplit=0)
+    @pytest.mark.parametrize('s, maxsplit',
+                             [("foo bar baz", 1), ("  foo bar baz  ", 0)])
+    def test_str_split_maxsplit(self, s, maxsplit):
+        """Test if the behavior matches str.split with given maxsplit."""
+        actual = split.simple_split(s, maxsplit=maxsplit)
+        expected = s.rstrip().split(maxsplit=maxsplit)
         assert actual == expected
 
     @pytest.mark.parametrize('test, expected', TESTS.items())

--- a/tests/misc/test_split.py
+++ b/tests/misc/test_split.py
@@ -19,7 +19,7 @@
 
 """Tests for qutebrowser.misc.split."""
 
-import unittest
+import pytest
 
 from qutebrowser.misc import split
 
@@ -103,38 +103,35 @@ foo\ bar/foo bar/foo\ bar/
 áéíóú/áéíóú/áéíóú/
 """
 
+test_data_lines = test_data.strip().splitlines()
 
-class SplitTests(unittest.TestCase):
 
+class TestSplit:
     """Test split."""
 
-    def test_split(self):
+    @pytest.mark.parametrize('cmd, out',
+                             [case.split('/')[:-2] for case in test_data_lines])
+    def test_split(self, cmd, out):
         """Test splitting."""
-        for case in test_data.strip().splitlines():
-            cmd, out = case.split('/')[:-2]
-            with self.subTest(cmd=cmd):
-                items = split.split(cmd)
-                self.assertEqual(items, out.split('|'))
+        items = split.split(cmd)
+        assert items == out.split('|')
 
-    def test_split_keep_original(self):
+    @pytest.mark.parametrize('cmd',
+                             [case.split('/')[0] for case in test_data_lines])
+    def test_split_keep_original(self, cmd):
         """Test if splitting with keep=True yields the original string."""
-        for case in test_data.strip().splitlines():
-            cmd = case.split('/')[0]
-            with self.subTest(cmd=cmd):
-                items = split.split(cmd, keep=True)
-                self.assertEqual(''.join(items), cmd)
+        items = split.split(cmd, keep=True)
+        assert ''.join(items) == cmd
 
-    def test_split_keep(self):
+    @pytest.mark.parametrize('cmd, _mid, out',
+                             [case.split('/')[:-1] for case in test_data_lines])
+    def test_split_keep(self, cmd, _mid, out):
         """Test splitting with keep=True."""
-        for case in test_data.strip().splitlines():
-            cmd, _mid, out = case.split('/')[:-1]
-            with self.subTest(cmd=cmd):
-                items = split.split(cmd, keep=True)
-                self.assertEqual(items, out.split('|'))
+        items = split.split(cmd, keep=True)
+        assert items == out.split('|')
 
 
-class SimpleSplitTests(unittest.TestCase):
-
+class TestSimpleSplit:
     """Test simple_split."""
 
     TESTS = {
@@ -145,27 +142,22 @@ class SimpleSplitTests(unittest.TestCase):
         'foo\nbar': ['foo', '\nbar'],
     }
 
-    def test_str_split(self):
+    @pytest.mark.parametrize('test', TESTS)
+    def test_str_split(self, test):
         """Test if the behavior matches str.split."""
-        for test in self.TESTS:
-            with self.subTest(string=test):
-                self.assertEqual(split.simple_split(test),
-                                 test.rstrip().split())
+        assert split.simple_split(test) == test.rstrip().split()
 
     def test_str_split_maxsplit_1(self):
         """Test if the behavior matches str.split with maxsplit=1."""
-        string = "foo bar baz"
-        self.assertEqual(split.simple_split(string, maxsplit=1),
-                         string.rstrip().split(maxsplit=1))
+        s = "foo bar baz"
+        assert split.simple_split(s, maxsplit=1) == s.rstrip().split(maxsplit=1)
 
     def test_str_split_maxsplit_0(self):
         """Test if the behavior matches str.split with maxsplit=0."""
-        string = "  foo bar baz  "
-        self.assertEqual(split.simple_split(string, maxsplit=0),
-                         string.rstrip().split(maxsplit=0))
+        s = "  foo bar baz  "
+        assert split.simple_split(s, maxsplit=0) == s.rstrip().split(maxsplit=0)
 
-    def test_split_keep(self):
+    @pytest.mark.parametrize('test, expected', TESTS.items())
+    def test_split_keep(self, test, expected):
         """Test splitting with keep=True."""
-        for test, expected in self.TESTS.items():
-            with self.subTest(string=test):
-                self.assertEqual(split.simple_split(test, keep=True), expected)
+        assert split.simple_split(test, keep=True) == expected

--- a/tests/misc/test_split.py
+++ b/tests/misc/test_split.py
@@ -131,9 +131,10 @@ class TestSplit:
 
     @pytest.fixture(params=_parse_split_test_data_str())
     def split_test_case(self, request):
-        """
-        Fixture that will automatically parametrize all tests the depend on it
-        using the parsed test case data.
+        """Fixture to automatically parametrize all depending tests.
+
+        It will use the test data from test_data_str, parsed using
+        _parse_split_test_data_str().
         """
         return request.param
 

--- a/tests/utils/overflow_test_cases.py
+++ b/tests/utils/overflow_test_cases.py
@@ -1,0 +1,70 @@
+# vim: ft=python fileencoding=utf-8 sts=4 sw=4 et:
+
+# Copyright 2014-2015 Florian Bruhin (The Compiler) <mail@qutebrowser.org>
+#
+# This file is part of qutebrowser.
+#
+# qutebrowser is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# qutebrowser is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with qutebrowser.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Provides test data for overflow checking.
+
+Module attributes:
+    INT32_MIN: Minimum valid value for a signed int32.
+    INT32_MAX: Maximum valid value for a signed int32.
+    INT64_MIN: Minimum valid value for a signed int64.
+    INT64_MAX: Maximum valid value for a signed int64.
+    GOOD_VALUES: A dict of types mapped to a list of good values.
+    BAD_VALUES: A dict of types mapped to a list of bad values.
+"""
+
+INT32_MIN = -(2 ** 31)
+INT32_MAX = 2 ** 31 - 1
+INT64_MIN = -(2 ** 63)
+INT64_MAX = 2 ** 63 - 1
+
+GOOD_VALUES = {
+    'int': [-1, 0, 1, 23.42, INT32_MIN, INT32_MAX],
+    'int64': [-1, 0, 1, 23.42, INT64_MIN, INT64_MAX],
+}
+
+BAD_VALUES = {
+    'int': [(INT32_MIN - 1, INT32_MIN),
+            (INT32_MAX + 1, INT32_MAX),
+            (float(INT32_MAX + 1), INT32_MAX)],
+    'int64': [(INT64_MIN - 1, INT64_MIN),
+              (INT64_MAX + 1, INT64_MAX),
+              (float(INT64_MAX + 1), INT64_MAX)],
+}
+
+
+def iter_good_values():
+    """
+    Yields pairs of (c data type, value) which should pass overflow
+    checking.
+    """
+    for ctype, values in GOOD_VALUES.items():
+        for value in values:
+            yield ctype, value
+
+
+def iter_bad_values():
+    """
+    Yields pairs of (c type, value, repl) for values which don't pass
+    overflow checking, and a value they should be replaced with if overflow
+    checking should not be fatal.
+    """
+    for ctype, values in BAD_VALUES.items():
+        for value, repl in values:
+            yield ctype, value, repl

--- a/tests/utils/overflow_test_cases.py
+++ b/tests/utils/overflow_test_cases.py
@@ -50,9 +50,9 @@ BAD_VALUES = {
 
 
 def iter_good_values():
-    """
-    Yields pairs of (c data type, value) which should pass overflow
-    checking.
+    """Yield "good" (C data type, value) tuples.
+
+    Those should pass overflow checking.
     """
     for ctype, values in GOOD_VALUES.items():
         for value in values:
@@ -60,10 +60,10 @@ def iter_good_values():
 
 
 def iter_bad_values():
-    """
-    Yields pairs of (c type, value, repl) for values which don't pass
-    overflow checking, and a value they should be replaced with if overflow
-    checking should not be fatal.
+    """Yield pairs of "bad" (C type, value, repl) tuples.
+
+    Theose should not pass overflow checking. The third value is the value they
+    should be replaced with if overflow checking should not be fatal.
     """
     for ctype, values in BAD_VALUES.items():
         for value, repl in values:

--- a/tests/utils/test_qtutils.py
+++ b/tests/utils/test_qtutils.py
@@ -28,6 +28,7 @@ from qutebrowser.utils import qtutils
 
 
 class TestCheckOverflow:
+
     """Test check_overflow.
 
     Class attributes:
@@ -66,8 +67,8 @@ class TestCheckOverflow:
         qtutils.check_overflow(val, ctype)
 
     @pytest.mark.parametrize('ctype, val',
-                             [(ctype, val) for ctype, vals in BAD_VALUES.items()
-                              for (val, _) in vals])
+                             [(ctype, val) for ctype, vals in
+                              BAD_VALUES.items() for (val, _) in vals])
     def test_bad_values_fatal(self, ctype, val):
         """Test values which are outside bounds with fatal=True."""
         with pytest.raises(OverflowError):
@@ -83,12 +84,16 @@ class TestCheckOverflow:
 
 
 class TestGetQtArgs:
+
     """Tests for get_args."""
 
     @pytest.fixture
     def parser(self, mocker):
+        """Fixture to provide an argparser.
+
+        Monkey-patches .exit() of the argparser so it doesn't exit on errors.
+        """
         parser = qutebrowser.get_argparser()
-        # monkey-patch .exit() of the argparser so it doesn't exit.
         mocker.patch.object(parser, 'exit', side_effect=Exception)
         return parser
 

--- a/tests/utils/test_qtutils.py
+++ b/tests/utils/test_qtutils.py
@@ -29,8 +29,8 @@ import overflow_test_cases
 
 
 class TestCheckOverflow:
-    """Test check_overflow.
-    """
+
+    """Test check_overflow."""
 
     @pytest.mark.parametrize('ctype, val',
                              overflow_test_cases.iter_good_values())
@@ -55,6 +55,7 @@ class TestCheckOverflow:
 
 
 class TestGetQtArgs:
+
     """Tests for get_args."""
 
     @pytest.fixture


### PR DESCRIPTION
Converted the last tests which use `subTest` to `@pytest.mark.parametrize`.

Fixed #6 
