### PR TITLE
Add tests for CommandRunner/KeyConfigParser.

### DIFF
--- a/tests/commands/test_runners.py
+++ b/tests/commands/test_runners.py
@@ -1,0 +1,44 @@
+# vim: ft=python fileencoding=utf-8 sts=4 sw=4 et:
+
+# Copyright 2015 Florian Bruhin (The Compiler) <mail@qutebrowser.org>
+#
+# This file is part of qutebrowser.
+#
+# qutebrowser is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# qutebrowser is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with qutebrowser.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for qutebrowser.commands.runners."""
+
+import pytest
+
+from qutebrowser.commands import runners, cmdexc
+
+
+class TestCommandRunner:
+
+    """Tests for CommandRunner."""
+
+    def test_parse_all(self, cmdline_test):
+        """Test parsing of commands.
+
+        See https://github.com/The-Compiler/qutebrowser/issues/615
+
+        Args:
+            cmdline_test: A pytest fixture which provides testcases.
+        """
+        cr = runners.CommandRunner(0)
+        if cmdline_test.valid:
+            list(cr.parse_all(cmdline_test.cmd, aliases=False))
+        else:
+            with pytest.raises(cmdexc.NoSuchCommandError):
+                list(cr.parse_all(cmdline_test.cmd, aliases=False))

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -157,6 +157,27 @@ class TestConfigParser:
             self.cfg.get('general', 'bar')  # pylint: disable=bad-config-call
 
 
+class TestKeyConfigParser:
+
+    """Test config.parsers.keyconf.KeyConfigParser."""
+
+    def test_cmd_binding(self, cmdline_test):
+        """Test various command bindings.
+
+        See https://github.com/The-Compiler/qutebrowser/issues/615
+
+        Args:
+            cmdline_test: A pytest fixture which provides testcases.
+        """
+        kcp = keyconf.KeyConfigParser(None, None)
+        kcp._cur_section = 'normal'
+        if cmdline_test.valid:
+            kcp._read_command(cmdline_test.cmd)
+        else:
+            with pytest.raises(keyconf.KeyConfigError):
+                kcp._read_command(cmdline_test.cmd)
+
+
 class TestDefaultConfig:
 
     """Test validating of the default config."""


### PR DESCRIPTION
I had to fix a bug for this code (https://github.com/The-Compiler/qutebrowser/issues/615) so I thought I might as well write some tests :wink:

I used a parametrized fixture to provide the test cases, as I need them in two different places - does that approach make sense?
