### PR TITLE
Use a single QNetworkAccessManager per session.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,15 +49,23 @@ def unicode_encode_err():
                               'fake exception')  # reason
 
 
+@pytest.fixture(scope='session')
+def qnam():
+    """Session-wide QNetworkAccessManager."""
+    from PyQt5.QtNetwork import QNetworkAccessManager
+    nam = QNetworkAccessManager()
+    nam.setNetworkAccessible(QNetworkAccessManager.NotAccessible)
+    return nam
+
+
 @pytest.fixture
-def webpage():
+def webpage(qnam):
     """Get a new QWebPage object."""
     from PyQt5.QtWebKitWidgets import QWebPage
-    from PyQt5.QtNetwork import QNetworkAccessManager
 
     page = QWebPage()
-    nam = page.networkAccessManager()
-    nam.setNetworkAccessible(QNetworkAccessManager.NotAccessible)
+    page.networkAccessManager().deleteLater()
+    page.setNetworkAccessManager(qnam)
     return page
 
 


### PR DESCRIPTION
An attempt at maybe at least getting #22 a bit less as there are less `QNetworkAccessManager`s and the crash occurs somewhere in `QtNetwork`.

Will it help? No idea. But I have no idea what to do about it anyways...
