### PR TITLE
Markers

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ deps =
 # on Ubuntu Trusty.
 commands =
     {envpython} scripts/link_pyqt.py --tox {envdir}
-    {envpython} -m py.test {posargs}
+    {envpython} -m py.test --strict {posargs}
 
 [testenv:coverage]
 deps =
@@ -36,7 +36,7 @@ deps =
     cov-core==1.15.0
 commands =
     {[testenv:mkvenv]commands}
-    {envpython} -m py.test --cov qutebrowser --cov-report term --cov-report html {posargs}
+    {envpython} -m py.test --strict --cov qutebrowser --cov-report term --cov-report html {posargs}
 
 [testenv:misc]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -109,3 +109,5 @@ commands =
 
 [pytest]
 norecursedirs = .tox .venv
+markers =
+    gui: Tests using the GUI (e.g. spawning widgets)


### PR DESCRIPTION
This registers the _gui_ marker as recommended [in the docs](http://pytest.org/latest/example/markers.html?highlight=custom%20marker#registering-markers) and adds `--strict` to the pytest invocations because I don't see why not :wink:
